### PR TITLE
Fix typo in definition of 2019,Q1,Q2 type format

### DIFF
--- a/static/custom-format.js
+++ b/static/custom-format.js
@@ -36,7 +36,7 @@ require(['d3'], function(d3) {
             formats = [
                 { l: '2015', f: 'YYYY' },
                 { l: '2015 Q1', f: 'YYYY [Q]Q' },
-                { l: '2015/Q1', f: 'YYYY|\QQ' },
+                { l: '2015/Q1', f: 'YYYY|[Q]Q' },
                 { l: '2015 Apr', f: 'YYYY|MMM' },
                 { l: '’15', f: '’YY' },
                 { l: 'April', f: 'MMMM' },


### PR DESCRIPTION
This typo has been causing incorrect formatting of the above date format for a while now. This PR fixes that

![image](https://user-images.githubusercontent.com/19191012/72617682-d5bbdf80-3939-11ea-84f7-a77c4430c580.png)
